### PR TITLE
chore: update WordPress tested version to 6.9

### DIFF
--- a/omnisend-for-paid-memberships-pro/class-omnisend-paidmembershipsproaddon.php
+++ b/omnisend-for-paid-memberships-pro/class-omnisend-paidmembershipsproaddon.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Omnisend for Paid Memberships Pro Add-On
  * Description: A Paid Memberships Pro add-on to sync contacts with Omnisend. In collaboration with Paid Memberships Pro plugin it enables better customer tracking
- * Version: 1.0.8
+ * Version: 1.0.9
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
  * Developer: Omnisend
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'OMNISEND_MEMBERSHIPS_ADDON_NAME', 'Omnisend for Paid Memberships Pro Add-On' );
-define( 'OMNISEND_MEMBERSHIPS_ADDON_VERSION', '1.0.8' );
+define( 'OMNISEND_MEMBERSHIPS_ADDON_VERSION', '1.0.9' );
 
 spl_autoload_register( array( 'Omnisend_PaidMembershipsProAddOn', 'autoloader' ) );
 add_action( 'plugins_loaded', array( 'Omnisend_PaidMembershipsProAddOn', 'check_plugin_requirements' ) );

--- a/omnisend-for-paid-memberships-pro/readme.txt
+++ b/omnisend-for-paid-memberships-pro/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Paid Memberships Pro Add-On
 Contributors: omnisend
 Tags: Paid Memberships Pro, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 6.6
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.8
+Stable tag: 1.0.9
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -52,6 +52,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.0.9 =
+* Tested up to WordPress 6.9
 
 = 1.0.8 =
 * Update screenshots


### PR DESCRIPTION
## What?
Update WordPress tested version to 6.9 and bump plugin version to 1.0.9.

## Why?
Plugin has been tested with WordPress 6.9.