### PR TITLE
Update for WordPress 7.0 compatibility

### DIFF
--- a/omnisend-for-paid-memberships-pro/class-omnisend-paidmembershipsproaddon.php
+++ b/omnisend-for-paid-memberships-pro/class-omnisend-paidmembershipsproaddon.php
@@ -2,7 +2,8 @@
 /**
  * Plugin Name: Omnisend for Paid Memberships Pro Add-On
  * Description: A Paid Memberships Pro add-on to sync contacts with Omnisend. In collaboration with Paid Memberships Pro plugin it enables better customer tracking
- * Version: 1.0.9
+ * Version: 1.0.10
+ * Requires PHP: 7.4
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
  * Developer: Omnisend
@@ -26,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'OMNISEND_MEMBERSHIPS_ADDON_NAME', 'Omnisend for Paid Memberships Pro Add-On' );
-define( 'OMNISEND_MEMBERSHIPS_ADDON_VERSION', '1.0.9' );
+define( 'OMNISEND_MEMBERSHIPS_ADDON_VERSION', '1.0.10' );
 
 spl_autoload_register( array( 'Omnisend_PaidMembershipsProAddOn', 'autoloader' ) );
 add_action( 'plugins_loaded', array( 'Omnisend_PaidMembershipsProAddOn', 'check_plugin_requirements' ) );

--- a/omnisend-for-paid-memberships-pro/readme.txt
+++ b/omnisend-for-paid-memberships-pro/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Paid Memberships Pro Add-On
 Contributors: omnisend
 Tags: Paid Memberships Pro, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.0.9
+Stable tag: 1.0.10
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -52,6 +52,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.0.10 =
+* Updated for WordPress 7.0 compatibility.
 
 = 1.0.9 =
 * Tested up to WordPress 6.9


### PR DESCRIPTION
## What?

Update plugin for WordPress 7.0 compatibility:
- Add `Requires PHP: 7.4` header
- Update `Tested up to: 7.0`
- Version bump 1.0.9 → 1.0.10

## Why?

WordPress 7.0 raises the minimum PHP version to 7.4. This update declares compatibility with WP 7.0 and aligns the PHP requirement.

Initiated-by:paulius.l@omnisend.com

Link to Devin session: https://app.devin.ai/sessions/e77377e050884548b15f4db75899626a
Requested by: @plutzilla