### PR TITLE
Update for WordPress 7.1 compatibility

### DIFF
--- a/omnisend-for-paid-memberships-pro/class-omnisend-paidmembershipsproaddon.php
+++ b/omnisend-for-paid-memberships-pro/class-omnisend-paidmembershipsproaddon.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Omnisend for Paid Memberships Pro Add-On
  * Description: A Paid Memberships Pro add-on to sync contacts with Omnisend. In collaboration with Paid Memberships Pro plugin it enables better customer tracking
- * Version: 1.1.0
+ * Version: 1.1.1
  * Requires PHP: 7.4
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'OMNISEND_MEMBERSHIPS_ADDON_NAME', 'Omnisend for Paid Memberships Pro Add-On' );
-define( 'OMNISEND_MEMBERSHIPS_ADDON_VERSION', '1.1.0' );
+define( 'OMNISEND_MEMBERSHIPS_ADDON_VERSION', '1.1.1' );
 
 spl_autoload_register( array( 'Omnisend_PaidMembershipsProAddOn', 'autoloader' ) );
 add_action( 'plugins_loaded', array( 'Omnisend_PaidMembershipsProAddOn', 'check_plugin_requirements' ) );

--- a/omnisend-for-paid-memberships-pro/readme.txt
+++ b/omnisend-for-paid-memberships-pro/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for Paid Memberships Pro Add-On
 Contributors: omnisend
 Tags: Paid Memberships Pro, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -52,6 +52,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.1.1 =
+* Confirmed compatibility with WordPress 7.1.
 
 = 1.1.0 =
 * Suggest privacy policy text via the WordPress privacy policy content API.


### PR DESCRIPTION
## What?

- Bump `Tested up to: 7.1` in readme.txt
- Requires PHP unchanged at 7.4 — WP 7.1 minimum is still 7.4
- Patch version 1.1.0 → 1.1.1

## Why?

WordPress 7.1 (Field Guide: https://make.wordpress.org/core/2026/08/05/wordpress-7-1-field-guide/). Audit: no matching surfaces; PHP-hook only.